### PR TITLE
Add i18n class and register it as a core service

### DIFF
--- a/src/Contract/Core/I18n.php
+++ b/src/Contract/Core/I18n.php
@@ -1,0 +1,11 @@
+<?php
+namespace Intraxia\Jaxion\Contract\Core;
+
+interface I18n {
+	/**
+	 * Loads the plugin's textdomain.
+	 *
+	 * @return void
+	 */
+	public function load_plugin_textdomain();
+}

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -45,7 +45,6 @@ class Application extends Container implements ApplicationContract {
 
 		$this->register_constants( $file );
 		$this->register_core_services();
-		$this->load_i18n();
 
 		register_activation_hook( $file, array( $this, 'activate' ) );
 		register_deactivation_hook( $file, array( $this, 'deactivate' ) );
@@ -143,16 +142,8 @@ class Application extends Container implements ApplicationContract {
 		$this->share( array( 'loader' => 'Intraxia\Jaxion\Contract\Core\Loader' ), function ( $app ) {
 			return new Loader( $app );
 		} );
-	}
-
-	/**
-	 * Load's the plugin's translation files.
-	 */
-	private function load_i18n() {
-		load_plugin_textdomain(
-			$this->fetch( 'basename' ),
-			false,
-			basename( $this->fetch( 'path' ) ) . '/languages/'
-		);
+		$this->share( array( 'i18n' => 'Intaxia\Jaxion\Contract\Core\I18n' ), function ( $app ) {
+			return new I18n( $app->fetch( 'basename' ), $app->fetch( 'path' ) );
+		} );
 	}
 }

--- a/src/Core/I18n.php
+++ b/src/Core/I18n.php
@@ -1,0 +1,63 @@
+<?php
+namespace Intraxia\Jaxion\Core;
+
+use Intraxia\Jaxion\Contract\Core\HasActions;
+use Intraxia\Jaxion\Contract\Core\I18n as I18nContract;
+
+/**
+ * Class I18n
+ *
+ * @package    Intraxia\Jaxion
+ * @subpackage Core
+ */
+class I18n implements I18nContract, HasActions {
+	/**
+	 * Plugin basename
+	 *
+	 * @var string
+	 */
+	private $basename;
+
+	/**
+	 * Plugin path.
+	 *
+	 * @var string
+	 */
+	private $path;
+
+	/**
+	 * I18n constructor.
+	 *
+	 * @param string $basename Plugin basename.
+	 * @param string $path     Plugin path.
+	 */
+	public function __construct( $basename, $path ) {
+		$this->basename = $basename;
+		$this->path = $path;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function load_plugin_textdomain() {
+		load_plugin_textdomain(
+			$this->basename,
+			false,
+			basename( $this->path ) . '/languages/'
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function action_hooks() {
+		return array(
+			array(
+				'hook'   => 'init',
+				'method' => 'load_plugin_textdomain',
+			),
+		);
+	}
+}

--- a/tests/Core/ApplicationTest.php
+++ b/tests/Core/ApplicationTest.php
@@ -85,18 +85,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 
 		$app     = new App( __FILE__ );
 		$actions = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasActions' );
-
-		$app->remove( 'loader' )
-			->define( 'loader', function () use ( $actions ) {
-				$loader = Mockery::mock( 'Intraxia\Jaxion\Core\Loader' );
-				$loader->shouldReceive( 'register_actions' )
-					->once()
-					->with( $actions );
-
-				WP_Mock::expectActionAdded( 'plugins_loaded', array( $loader, 'run' ) );
-
-				return $loader;
-			} );
+		$this->mock_loader( $app )
+			->shouldReceive( 'register_actions' )
+			->once()
+			->with( $actions );
 		$app->define( 'actions', $actions );
 
 		$app->boot();
@@ -107,18 +99,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 
 		$app     = new App( __FILE__ );
 		$filters = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasFilters' );
-
-		$app->remove( 'loader' )
-			->define( 'loader', function () use ( $filters ) {
-				$loader = Mockery::mock( 'Intraxia\Jaxion\Core\Loader' );
-				$loader->shouldReceive( 'register_filters' )
-					->once()
-					->with( $filters );
-
-				WP_Mock::expectActionAdded( 'plugins_loaded', array( $loader, 'run' ) );
-
-				return $loader;
-			} );
+		$this->mock_loader( $app )
+			->shouldReceive( 'register_filters' )
+			->once()
+			->with( $filters );
 		$app->define( 'filters', $filters );
 
 		$app->boot();
@@ -129,18 +113,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 
 		$app     = new App( __FILE__ );
 		$shortcode = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasShortcode' );
-
-		$app->remove( 'loader' )
-			->define( 'loader', function () use ( $shortcode ) {
-				$loader = Mockery::mock( 'Intraxia\Jaxion\Core\Loader' );
-				$loader->shouldReceive( 'register_shortcode' )
-					->once()
-					->with( $shortcode );
-
-				WP_Mock::expectActionAdded( 'plugins_loaded', array( $loader, 'run' ) );
-
-				return $loader;
-			} );
+		$this->mock_loader( $app )
+			->shouldReceive( 'register_shortcode' )
+			->once()
+			->with( $shortcode );
 		$app->define( 'filters', $shortcode );
 
 		$app->boot();
@@ -150,8 +126,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		WP_Mock::wpPassthruFunction( 'plugin_dir_url', array( 'times' => 1 ) );
 		WP_Mock::wpPassthruFunction( 'plugin_dir_path', array( 'times' => 1 ) );
 		WP_Mock::wpPassthruFunction( 'plugin_basename', array( 'times' => 1 ) );
-
-		WP_Mock::wpPassthruFunction( 'load_plugin_textdomain', array( 'times' => 1 ) );
 		WP_Mock::wpPassthruFunction( 'register_activation_hook', array( 'times' => 1 ) );
 		WP_Mock::wpPassthruFunction( 'register_deactivation_hook', array( 'times' => 1 ) );
 	}
@@ -161,5 +135,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		App::shutdown();
 		Mockery::close();
 		WP_Mock::tearDown();
+	}
+
+	private function mock_loader( $app ) {
+		$loader = Mockery::mock( 'Intraxia\Jaxion\Core\Loader' );
+		$loader->shouldReceive( 'register_actions' )
+		       ->once()
+		       ->with( Mockery::type( 'Intraxia\Jaxion\Contract\Core\I18n' ) );
+		WP_Mock::expectActionAdded( 'plugins_loaded', array( $loader, 'run' ) );
+
+		$app->remove( 'loader' )
+			->define( 'loader', function () use ( $loader ) {
+				return $loader;
+			} );
+
+		return $loader;
 	}
 }


### PR DESCRIPTION
This ensures the i18n class loads the plugin's textdomain. For now, this
does little more, but can maybe be extended later to provide other
i18n functionality.

Fixes #8.