### PR TITLE
Allow hook to be passed to $condition on admin

### DIFF
--- a/src/Assets/Register.php
+++ b/src/Assets/Register.php
@@ -8,7 +8,7 @@ use Intraxia\Jaxion\Contract\Assets\Register as RegisterContract;
  *
  * Provides a consistent interface for registering static assets with WordPress.
  *
- * @package Intraxia\Jaxion
+ * @package    Intraxia\Jaxion
  * @subpackage Register
  */
 class Register implements RegisterContract {
@@ -60,8 +60,8 @@ class Register implements RegisterContract {
 	 * @param string $version
 	 */
 	public function __construct( $url, $version = null ) {
-		$this->url = $url;
-		$this->version = $version ? : null; // Empty string should remain null.
+		$this->url     = $url;
+		$this->version = $version ?: null; // Empty string should remain null.
 	}
 
 	/**
@@ -119,22 +119,26 @@ class Register implements RegisterContract {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param string $hook Passes a string representing the current page.
 	 */
-	public function enqueue_admin_scripts() {
+	public function enqueue_admin_scripts( $hook ) {
 		foreach ( $this->scripts as $script ) {
 			if ( in_array( $script['type'], array( 'admin', 'shared' ) ) ) {
-				$this->enqueue_script( $script );
+				$this->enqueue_script( $script, $hook );
 			}
 		}
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @param string $hook Passes a string representing the current page.
 	 */
-	public function enqueue_admin_styles() {
+	public function enqueue_admin_styles( $hook ) {
 		foreach ( $this->styles as $style ) {
 			if ( in_array( $style['type'], array( 'admin', 'shared' ) ) ) {
-				$this->enqueue_style( $style );
+				$this->enqueue_style( $style, $hook );
 			}
 		}
 	}
@@ -168,10 +172,11 @@ class Register implements RegisterContract {
 	/**
 	 * Enqueues an individual script if the style's condition is met.
 	 *
-	 * @param array $script
+	 * @param array  $script The script attachment callback.
+	 * @param string $hook   The location hook. Only passed on admin side.
 	 */
-	protected function enqueue_script( $script ) {
-		if ( $script['condition']() ) {
+	protected function enqueue_script( $script, $hook = null ) {
+		if ( $script['condition']( $hook ) ) {
 			wp_enqueue_script(
 				$script['handle'],
 				$this->url . $script['src'] . '.js',
@@ -197,10 +202,11 @@ class Register implements RegisterContract {
 	/**
 	 * Enqueues an individual stylesheet if the style's condition is met.
 	 *
-	 * @param array $style
+	 * @param array  $style The style attachment callback.
+	 * @param string $hook  The location hook.
 	 */
-	protected function enqueue_style( $style ) {
-		if ( $style['condition']() ) {
+	protected function enqueue_style( $style, $hook = null ) {
+		if ( $style['condition']( $hook ) ) {
 			wp_enqueue_style(
 				$style['handle'],
 				$this->url . $style['src'] . '.css',

--- a/src/Contract/Assets/Register.php
+++ b/src/Contract/Assets/Register.php
@@ -41,11 +41,15 @@ interface Register extends HasActions {
 
 	/**
 	 * Enqueues the admin & shared scripts on the Register.
+	 *
+	 * @param string $hook Passes a string representing the current page.
 	 */
-	public function enqueue_admin_scripts();
+	public function enqueue_admin_scripts( $hook );
 
 	/**
 	 * Enqueues the admin & shared styles on the Register.
+	 *
+	 * @param string $hook Passes a string representing the current page.
 	 */
-	public function enqueue_admin_styles();
+	public function enqueue_admin_styles( $hook );
 }

--- a/tests/Assets/RegisterTest.php
+++ b/tests/Assets/RegisterTest.php
@@ -115,7 +115,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 			'args'  => array( 'adminScript', 'test.com/test.js', array(), null, false ),
 		) );
 
-		$this->assets->enqueue_admin_scripts();
+		$this->assets->enqueue_admin_scripts( 'jaxion_test' );
 	}
 
 	public function test_should_not_enqueue_admin_script_if_false_condition() {
@@ -132,7 +132,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 			'times' => 0,
 		) );
 
-		$this->assets->enqueue_admin_scripts();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_enqueue_admin_style() {
@@ -150,7 +150,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 			'args'  => array( 'adminStyle', 'test.com/test.css', array(), null, 'all' ),
 		) );
 
-		$this->assets->enqueue_admin_styles();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_not_enqueue_admin_style_if_false_condition() {
@@ -167,7 +167,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 			'times' => 0,
 		) );
 
-		$this->assets->enqueue_admin_styles();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_enqueue_shared_script() {
@@ -186,7 +186,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$this->assets->enqueue_web_scripts();
-		$this->assets->enqueue_admin_scripts();
+		$this->assets->enqueue_admin_scripts( 'jaxion_test' );
 	}
 
 	public function test_should_not_enqueue_shared_script_if_false_condition() {
@@ -204,7 +204,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$this->assets->enqueue_web_scripts();
-		$this->assets->enqueue_admin_scripts();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_enqueue_shared_style() {
@@ -223,7 +223,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$this->assets->enqueue_web_styles();
-		$this->assets->enqueue_admin_styles();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_not_enqueue_shared_style_if_false_condition() {
@@ -241,7 +241,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 		) );
 
 		$this->assets->enqueue_web_styles();
-		$this->assets->enqueue_admin_styles();
+		$this->assets->enqueue_admin_styles( 'jaxion_test' );
 	}
 
 	public function test_should_localize_script_if_set() {


### PR DESCRIPTION
The [admin side][1] passes a hook on the enqueue_scripts, which can
be used to determine whether an individual script/style should be
enqueued on a given page. The [web side][2] does not.

Supersedes #4.

  [1]: https://github.com/WordPress/WordPress/blob/3c7ea03cb0a3d16a2302bb65349a9429fd181389/wp-admin/admin-header.php#L85-L92
  [2]: https://github.com/WordPress/WordPress/blob/3c7ea03cb0a3d16a2302bb65349a9429fd181389/wp-includes/script-loader.php#L997-L1012