### PR TITLE
Add Config class for configuration data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ sudo: false
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "myclabs/php-enum": "dev-master"
   },
   "require-dev": {
-    "phpunit/phpunit": "~4.7.7",
+    "phpunit/phpunit": "~4.7.7|~5.0",
     "mockery/mockery": "~0.9.4",
     "10up/wp_mock": "0.1.*",
     "scrutinizer/ocular": "~1.1",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
   "name": "intraxia/jaxion",
   "description": "A WordPress plugin framework for modern WordPress development.",
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3.0",
+    "myclabs/php-enum": "dev-master"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.7.7",

--- a/src/Core/Application.php
+++ b/src/Core/Application.php
@@ -31,23 +31,27 @@ class Application extends Container implements ApplicationContract {
 	 * The Application constructor enforces the presence of of a single instance
 	 * of the Application. If an instance already exists, an Exception will be thrown.
 	 *
-	 * @param string $file
+	 * @param Config $config
 	 * @param array  $providers
 	 *
 	 * @throws ApplicationAlreadyBootedException
 	 */
-	public function __construct( $file, array $providers = array() ) {
+	public function __construct( $config, array $providers = array() ) {
 		if ( isset( static::$instances[ get_called_class() ] ) ) {
 			throw new ApplicationAlreadyBootedException;
 		}
 
 		static::$instances[ get_called_class() ] = $this;
 
-		$this->register_constants( $file );
-		$this->register_core_services();
+		if ( ! ( $config instanceof Config ) ) {
+			$config = new Config( ConfigType::PLUGIN, $config );
+		}
 
-		register_activation_hook( $file, array( $this, 'activate' ) );
-		register_deactivation_hook( $file, array( $this, 'deactivate' ) );
+		$this->register_constants( $config );
+		$this->register_core_services( $config );
+
+		register_activation_hook( $config->file, array( $this, 'activate' ) );
+		register_deactivation_hook( $config->file, array( $this, 'deactivate' ) );
 
 		parent::__construct( $providers );
 	}
@@ -60,7 +64,7 @@ class Application extends Container implements ApplicationContract {
 	public function boot() {
 		$loader = $this->fetch( 'loader' );
 
-		if ( ! $loader instanceof LoaderContract ) {
+		if ( ! ( $loader instanceof LoaderContract ) ) {
 			throw new UnexpectedValueException;
 		}
 
@@ -125,25 +129,38 @@ class Application extends Container implements ApplicationContract {
 	/**
 	 * Sets the plugin's url, path, and basename.
 	 *
-	 * @param string $file
+	 * @param Config $config
 	 */
-	private function register_constants( $file ) {
-		$this->share( 'file', $file );
-		$this->share( 'url', plugin_dir_url( $file ) );
-		$this->share( 'path', plugin_dir_path( $file ) );
-		$this->share( 'basename', $basename = plugin_basename( $file ) );
-		$this->share( 'slug', dirname( $basename ) );
+	private function register_constants( Config $config ) {
+		$this->share( 'file', function() use ( $config ) {
+			return $config->file;
+		} );
+		$this->share( 'url', function() use ( $config ) {
+			return $config->url;
+		} );
+		$this->share( 'path', function() use ( $config ) {
+			return $config->path;
+		} );
+		$this->share( 'basename', function() use ( $config ) {
+			return $config->basename;
+		} );
+		$this->share( 'slug', function() use ( $config ) {
+			return $config->slug;
+		} );
 		$this->share( 'version', static::VERSION );
 	}
 
 	/**
 	 * Registers the built-in services with the Application container.
+	 *
+	 * @param Config $config
 	 */
-	private function register_core_services() {
-		$this->share( array( 'loader' => 'Intraxia\Jaxion\Contract\Core\Loader' ), function ( $app ) {
-			return new Loader( $app );
+	private function register_core_services( Config $config ) {
+		$this->share( array( 'config' => 'Intraxia\Jaxion\Core\Config' ), $config );
+		$this->share( array( 'loader' => 'Intraxia\Jaxion\Contract\Core\Loader' ), function () {
+			return new Loader;
 		} );
-		$this->share( array( 'i18n' => 'Intaxia\Jaxion\Contract\Core\I18n' ), function ( $app ) {
+		$this->share( array( 'i18n' => 'Intaxia\Jaxion\Contract\Core\I18n' ), function ( Container $app ) {
 			return new I18n( $app->fetch( 'basename' ), $app->fetch( 'path' ) );
 		} );
 	}

--- a/src/Core/Config.php
+++ b/src/Core/Config.php
@@ -1,0 +1,108 @@
+<?php
+namespace Intraxia\Jaxion\Core;
+
+/**
+ * Class Config
+ *
+ * Configuration service to manage the
+ * configuration data of the plugin or theme.
+ *
+ * @package    Intraxia\Jaxion
+ * @subpackage Core
+ */
+class Config {
+	/**
+	 * Configuration type.
+	 *
+	 * @var ConfigType
+	 */
+	public $type;
+
+	/**
+	 * App entry file.
+	 *
+	 * @var string
+	 */
+	public $file;
+
+	/**
+	 * App url.
+	 *
+	 * @var string
+	 */
+	public $url;
+
+	/**
+	 * App path.
+	 *
+	 * @var string
+	 */
+	public $path;
+
+	/**
+	 * App slug.
+	 *
+	 * @var string
+	 */
+	public $slug;
+
+	/**
+	 * App basename.
+	 *
+	 * @var string
+	 */
+	public $basename;
+
+	/**
+	 * Loaded configuration files.
+	 *
+	 * @var array
+	 */
+	private $loaded = array();
+
+	/**
+	 * Config constructor.
+	 *
+	 * @param string $type
+	 * @param string $file
+	 */
+	public function __construct( $type, $file ) {
+		$this->type = new ConfigType( $type );
+		$this->file = $file;
+
+		switch ( $this->type->getValue() ) {
+			case ConfigType::PLUGIN:
+			case ConfigType::MU_PLUGIN:
+				$this->url = plugin_dir_url( $file );
+				$this->path = plugin_dir_path( $file );
+				$this->slug = dirname( $this->basename = plugin_basename( $file ) );
+				break;
+			case ConfigType::THEME:
+				$this->url = get_stylesheet_directory_uri() . '/';
+				$this->path = get_stylesheet_directory() . '/';
+				$this->slug = dirname( $this->basename = plugin_basename( $file ) );
+				break;
+		}
+	}
+
+	/**
+	 * Load a configuration JSON file from the config folder.
+	 *
+	 * @param string $filename
+	 *
+	 * @return array|null
+	 */
+	public function get_config_json( $filename ) {
+		if ( isset( $this->loaded[ $filename ] ) ) {
+			return $this->loaded[ $filename ];
+		}
+
+		$contents = file_get_contents( $this->path . 'config/' . $filename . '.json' );
+
+		if ( false === $contents ) {
+			return null;
+		}
+
+		return $this->loaded[ $filename ] = json_decode( $contents, true );
+	}
+}

--- a/src/Core/ConfigType.php
+++ b/src/Core/ConfigType.php
@@ -1,0 +1,18 @@
+<?php
+namespace Intraxia\Jaxion\Core;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Class ConfigType
+ *
+ * Enumeration of Configuaration types.
+ *
+ * @package    Intraxia\Jaxion
+ * @subpackage Core
+ */
+class ConfigType extends Enum {
+	const PLUGIN = 'plugin';
+	const THEME = 'theme';
+	const MU_PLUGIN = 'mu-plugin';
+}

--- a/tests/Assets/RegisterTest.php
+++ b/tests/Assets/RegisterTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Intraxia\Jaxion\Test\Assets;
 
+use Mockery;
 use WP_Mock;
 use Intraxia\Jaxion\Assets\Register;
 use ReflectionProperty;
@@ -15,6 +16,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 		parent::setUp();
 		WP_Mock::setUp();
 		$this->assets = new Register( 'test.com/' );
+		$this->assets->set_debug( true );
 	}
 
 	public function test_should_toggle_debug_mode() {
@@ -23,11 +25,11 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 
 		$this->assets->set_debug( true );
 
-		$this->assertSame( '.min', $min->getValue( $this->assets ) );
+		$this->assertSame( '', $min->getValue( $this->assets ) );
 
 		$this->assets->set_debug( false );
 
-		$this->assertSame( '', $min->getValue( $this->assets ) );
+		$this->assertSame( '.min', $min->getValue( $this->assets ) );
 	}
 
 	public function test_should_enqueue_web_script() {
@@ -273,6 +275,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase {
 
 	public function tearDown() {
 		parent::tearDown();
+		Mockery::close();
 		WP_Mock::tearDown();
 	}
 }

--- a/tests/Core/ApplicationTest.php
+++ b/tests/Core/ApplicationTest.php
@@ -2,6 +2,8 @@
 namespace Intraxia\Jaxion\Test\Core;
 
 use Intraxia\Jaxion\Core\Application as App;
+use Intraxia\Jaxion\Core\Config;
+use Intraxia\Jaxion\Core\ConfigType;
 use Mockery;
 use WP_Mock;
 use stdClass;
@@ -19,28 +21,31 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_get_instantiated_instance() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app1 = new App( __FILE__ );
+		$app1 = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 		$app2 = App::instance();
 
 		$this->assertSame( $app1, $app2 );
 	}
 
 	public function test_should_throw_exception_if_already_booted() {
+		$this->mock_config_functions( 2 );
 		$this->mock_constructor_functions();
 
-		new App( __FILE__ );
+		new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 
 		$this->setExpectedException( 'Intraxia\Jaxion\Core\ApplicationAlreadyBootedException' );
 
-		new App( __FILE__ );
+		new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 	}
 
 	public function test_should_shutdown() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		new App( __FILE__ );
+		new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 		App::shutdown();
 
 		$this->setExpectedException( 'Intraxia\Jaxion\Core\ApplicationNotBootedException' );
@@ -48,9 +53,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_have_constants() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app = new App( __FILE__ );
+		$app = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 
 		$this->assertTrue( isset( $app['url'] ) );
 		$this->assertTrue( isset( $app['path'] ) );
@@ -58,17 +64,19 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_have_services() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app = new App( __FILE__ );
+		$app = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 
 		$this->assertInstanceOf( 'Intraxia\Jaxion\Core\Loader', $app['loader'] );
 	}
 
 	public function test_should_throw_exception_if_not_loader() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app = new App( __FILE__ );
+		$app = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 
 		$app->remove( 'loader' )
 			->define( 'loader', function () {
@@ -81,9 +89,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_register_actions() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app     = new App( __FILE__ );
+		$app     = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 		$actions = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasActions' );
 		$this->mock_loader( $app )
 			->shouldReceive( 'register_actions' )
@@ -95,9 +104,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_register_filters() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app     = new App( __FILE__ );
+		$app     = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 		$filters = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasFilters' );
 		$this->mock_loader( $app )
 			->shouldReceive( 'register_filters' )
@@ -109,9 +119,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function test_should_register_shortcode() {
+		$this->mock_config_functions();
 		$this->mock_constructor_functions();
 
-		$app     = new App( __FILE__ );
+		$app     = new App( new Config( ConfigType::PLUGIN, __FILE__ ) );
 		$shortcode = Mockery::mock( 'Intraxia\Jaxion\Contract\Core\HasShortcode' );
 		$this->mock_loader( $app )
 			->shouldReceive( 'register_shortcode' )
@@ -122,12 +133,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase {
 		$app->boot();
 	}
 
-	protected function mock_constructor_functions() {
-		WP_Mock::wpPassthruFunction( 'plugin_dir_url', array( 'times' => 1 ) );
-		WP_Mock::wpPassthruFunction( 'plugin_dir_path', array( 'times' => 1 ) );
-		WP_Mock::wpPassthruFunction( 'plugin_basename', array( 'times' => 1 ) );
-		WP_Mock::wpPassthruFunction( 'register_activation_hook', array( 'times' => 1 ) );
-		WP_Mock::wpPassthruFunction( 'register_deactivation_hook', array( 'times' => 1 ) );
+	protected function mock_config_functions( $count = 1 ) {
+		WP_Mock::wpPassthruFunction( 'plugin_dir_url', array( 'times' => $count ) );
+		WP_Mock::wpPassthruFunction( 'plugin_dir_path', array( 'times' => $count ) );
+		WP_Mock::wpPassthruFunction( 'plugin_basename', array( 'times' => $count ) );
+	}
+
+	protected function mock_constructor_functions( $count = 1 ) {
+		WP_Mock::wpPassthruFunction( 'register_activation_hook', array( 'times' => $count ) );
+		WP_Mock::wpPassthruFunction( 'register_deactivation_hook', array( 'times' => $count ) );
 	}
 
 	public function tearDown() {


### PR DESCRIPTION
Allows `config/*.json` files to be read and added to the configuration
object and gets the initial values currently used by the core constants.